### PR TITLE
Make crate build on macos using pkg-config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 serde_json = { version = "1.0" }
+
+[build-dependencies]
+pkg-config = "0.3.27"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,13 @@
+fn main() {
+    #[cfg(target_os = "macos")]
+    {
+        let gmp_config = pkg_config::probe_library("gmp").unwrap();
+        for link_lib in gmp_config.libs {
+            println!("cargo:rustc-link-lib={}", link_lib);
+        }
+        for link_path in gmp_config.link_paths {
+            println!("cargo:rustc-link-search=native={}", link_path.to_str().expect("Path is not unicode"));
+        }
+    }
+}
+


### PR DESCRIPTION
### Problem
The rust-gmp-kzen crate would not link to gmp on MacOS.

### Solution
Made a build script that uses [pkg-config](https://crates.io/crates/pkg-config) to configure the gmp lib paths.